### PR TITLE
Refactored step prescription to speed it up.

### DIFF
--- a/examples/choleskyFactorization/Main.c
+++ b/examples/choleskyFactorization/Main.c
@@ -1,7 +1,4 @@
-
-   /***** AUTO-GENERATED FILE from file Cholesky.cnc - only generated if file does not exist (on running cncocr_t the first time) - feel free to edit *****/
-
-#include "Dispatch.h"
+#include "Context.h"
 
 void cncEnvIn(int argc, char **argv, Context *context) {
     CNC_REQUIRE(argc==4, "Usage: ./Cholesky matrixSize tileSize fileName (found %d args)\n", argc);
@@ -67,7 +64,7 @@ void cncEnvIn(int argc, char **argv, Context *context) {
     Put(time_handle, tag, context->startTime);
 
     // Start the computation
-    prescribeStep("kComputeStep", tag, context);
+    CNC_PRESCRIBE(kComputeStep, tag, context);
 
     // Set tag for the output step
     int totalTileCount = nt * (nt + 1) / 2;

--- a/examples/choleskyFactorization/kComputeStep.c
+++ b/examples/choleskyFactorization/kComputeStep.c
@@ -3,8 +3,8 @@
 void kComputeStep(int k, numTilesItem numTiles, Context *context) {
     for(k = 0; k < numTiles.item; k++){
         char *tagcontrolS1Tag1 = CREATE_TAG(k);
-        prescribeStep("kjComputeStep", tagcontrolS1Tag1, context);
-        prescribeStep("s1ComputeStep", tagcontrolS1Tag1, context);
+        CNC_PRESCRIBE(kjComputeStep, tagcontrolS1Tag1, context);
+        CNC_PRESCRIBE(s1ComputeStep, tagcontrolS1Tag1, context);
     }
 }
 

--- a/examples/choleskyFactorization/kjComputeStep.c
+++ b/examples/choleskyFactorization/kjComputeStep.c
@@ -4,8 +4,8 @@ void kjComputeStep(int k, numTilesItem numTiles, Context *context) {
     int j;
     for(j = k+1; j < numTiles.item; j++){
         char *tagcontrolS2Tag1 = CREATE_TAG(k, j);
-        prescribeStep("kjiComputeStep", tagcontrolS2Tag1, context);
-        prescribeStep("s2ComputeStep", tagcontrolS2Tag1, context);
+        CNC_PRESCRIBE(kjiComputeStep, tagcontrolS2Tag1, context);
+        CNC_PRESCRIBE(s2ComputeStep, tagcontrolS2Tag1, context);
     }
 }
 

--- a/examples/choleskyFactorization/kjiComputeStep.c
+++ b/examples/choleskyFactorization/kjiComputeStep.c
@@ -4,7 +4,7 @@ void kjiComputeStep(int k, int j, Context *context) {
     int i;
     for(i = k+1; i < j+1; i++){
         char *tagcontrolS3Tag0 = CREATE_TAG(k, j, i);
-        prescribeStep("s3ComputeStep", tagcontrolS3Tag0, context);
+        CNC_PRESCRIBE(s3ComputeStep, tagcontrolS3Tag0, context);
     }
 }
 

--- a/examples/rangeTest/Main.c
+++ b/examples/rangeTest/Main.c
@@ -1,5 +1,5 @@
 
-#include "Dispatch.h"
+#include "Context.h"
 
 void cncEnvIn(int argc, char **argv, Context *context) {
     // Sum from 0 until 10
@@ -24,10 +24,10 @@ void cncEnvIn(int argc, char **argv, Context *context) {
     }
 
     char *tagSATag2 = CREATE_TAG(x, y);
-    prescribeStep("StepA", tagSATag2, context);
+    CNC_PRESCRIBE(StepA, tagSATag2, context);
 
     char *tagSBTag3 = CREATE_TAG(x, y);
-    prescribeStep("StepB", tagSBTag3, context);
+    CNC_PRESCRIBE(StepB, tagSBTag3, context);
 
     char *tagOut = CREATE_TAG(x, y);
     setEnvOutTag(tagOut, context);

--- a/examples/simpleTest/Main.c
+++ b/examples/simpleTest/Main.c
@@ -1,5 +1,5 @@
 
-#include "Dispatch.h"
+#include "Context.h"
 
 void cncEnvIn(int argc, char **argv, Context *context) {
 
@@ -21,7 +21,7 @@ void cncEnvIn(int argc, char **argv, Context *context) {
 
     PRINTF("Starting parallel computation\n");
 
-    prescribeStep("Step0", tag, context);
+    CNC_PRESCRIBE(Step0, tag, context);
 
     char *tag2 = CREATE_TAG(2);
     setEnvOutTag(tag2, context);

--- a/examples/simpleTest/Step0.c
+++ b/examples/simpleTest/Step0.c
@@ -7,7 +7,7 @@ void Step0(int k, sizeItem size0, Context *context) {
 	int i;
 	for (i = 0; i < size0.item; i++) {
 		char *tagS1Tag1 = CREATE_TAG(i);
-		prescribeStep("Step1", tagS1Tag1, context);
+		CNC_PRESCRIBE(Step1, tagS1Tag1, context);
 	}
 }
 

--- a/examples/simpleTest/Step1.c
+++ b/examples/simpleTest/Step1.c
@@ -12,7 +12,7 @@ void Step1(int k, AiItem Ai, Context *context){
 	Put(Bi_handle, tagBi, context->Bi);
 
 	char *tagS2Tag2 = CREATE_TAG(k);
-	prescribeStep("Step2", tagS2Tag2, context);
+	CNC_PRESCRIBE(Step2, tagS2Tag2, context);
 
 }
 

--- a/src/DataDriven.h
+++ b/src/DataDriven.h
@@ -66,6 +66,7 @@ int getTag(char* tag, int pos);
 cncHandle_t cncGet(char* tag, ItemCollectionEntry ** hashmap);
 
 #define CREATE_ITEM_INSTANCE(guid, ptr, size) DBCREATE(guid, ptr, size, DB_PROP_NONE, NULL_GUID, NO_ALLOC)
+#define CNC_PRESCRIBE(stepName, tag, context) (context->stepName.depf(tag, context))
 
 #endif /* _DATA_DRIVEN_H */
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -7,6 +7,12 @@ DIST_DIR=
 OBJS=DataDriven.o
 HEADERS=cnc.h cnc_mm.h DataDriven.h
 
+ifeq ("$(OPT)","1")
+CFLAGS=-O2
+else
+CFLAGS=-g
+endif
+
 all: compile
 
 compile: $(OBJS)
@@ -21,7 +27,7 @@ clean:
 
 # we want to rebuild if .c or the headers are modified
 %.o: %.c $(HEADERS)
-	gcc -g -c $< -I$(OCR_HOME)/include -D__OCR__
+	gcc $(CFLAGS) -c $< -I$(OCR_HOME)/include -D__OCR__
 
 check_dist:
 ifeq ($(DIST_DIR),)


### PR DESCRIPTION
Should now include Context.h rather than Dispatch.h in Main.c files.

Added the EDT template GUID for each step function to the CnC context.

Use CNC_PRESCRIBE macro to prescribe steps (removed prescribeStep function).
CNC_PRESCRIBE takes the step name as an identifier rather than as a string.
The following sed command can be used to automatically fix prescriptions:

sed -i 's/prescribeStep("([^"]*)"/CNC_PRESCRIBE(\1/' *.c
