### PR TITLE
Removed createTag in favor of custom functions for each collection.

### DIFF
--- a/CnCLPGParser/lib/LPG_LICENSE_INFO
+++ b/CnCLPGParser/lib/LPG_LICENSE_INFO
@@ -1,0 +1,203 @@
+The JARs in this directory are part of the LALR Parser Generator (LPG).
+
+http://sourceforge.net/projects/lpg/
+
+LPG is distributed under the Eclipse Public License, included below.
+
+===============================================================================
+
+Eclipse Public License - v 1.0
+
+THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC 
+LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM 
+CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+"Contribution" means:
+
+a) in the case of the initial Contributor, the initial code and documentation 
+distributed under this Agreement, and
+b) in the case of each subsequent Contributor:
+i) changes to the Program, and
+ii) additions to the Program;
+where such changes and/or additions to the Program originate from and are 
+distributed by that particular Contributor. A Contribution 'originates' from a 
+Contributor if it was added to the Program by such Contributor itself or anyone 
+acting on such Contributor's behalf. Contributions do not include additions to 
+the Program which: (i) are separate modules of software distributed in 
+conjunction with the Program under their own license agreement, and (ii) are 
+not derivative works of the Program.
+"Contributor" means any person or entity that distributes the Program.
+
+"Licensed Patents" mean patent claims licensable by a Contributor which are 
+necessarily infringed by the use or sale of its Contribution alone or when 
+combined with the Program.
+
+"Program" means the Contributions distributed in accordance with this Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement, 
+including all Contributors.
+
+2. GRANT OF RIGHTS
+
+a) Subject to the terms of this Agreement, each Contributor hereby grants 
+Recipient a non-exclusive, worldwide, royalty-free copyright license to 
+reproduce, prepare derivative works of, publicly display, publicly perform, 
+distribute and sublicense the Contribution of such Contributor, if any, and 
+such derivative works, in source code and object code form.
+b) Subject to the terms of this Agreement, each Contributor hereby grants 
+Recipient a non-exclusive, worldwide, royalty-free patent license under 
+Licensed Patents to make, use, sell, offer to sell, import and otherwise 
+transfer the Contribution of such Contributor, if any, in source code and 
+object code form. This patent license shall apply to the combination of the 
+Contribution and the Program if, at the time the Contribution is added by the 
+Contributor, such addition of the Contribution causes such combination to be 
+covered by the Licensed Patents. The patent license shall not apply to any 
+other combinations which include the Contribution. No hardware per se is 
+licensed hereunder.
+c) Recipient understands that although each Contributor grants the licenses to 
+its Contributions set forth herein, no assurances are provided by any 
+Contributor that the Program does not infringe the patent or other intellectual 
+property rights of any other entity. Each Contributor disclaims any liability 
+to Recipient for claims brought by any other entity based on infringement of 
+intellectual property rights or otherwise. As a condition to exercising the 
+rights and licenses granted hereunder, each Recipient hereby assumes sole 
+responsibility to secure any other intellectual property rights needed, if any. 
+For example, if a third party patent license is required to allow Recipient to 
+distribute the Program, it is Recipient's responsibility to acquire that 
+license before distributing the Program.
+d) Each Contributor represents that to its knowledge it has sufficient 
+copyright rights in its Contribution, if any, to grant the copyright license 
+set forth in this Agreement.
+
+3. REQUIREMENTS
+
+A Contributor may choose to distribute the Program in object code form under 
+its own license agreement, provided that:
+
+a) it complies with the terms and conditions of this Agreement; and
+b) its license agreement:
+i) effectively disclaims on behalf of all Contributors all warranties and 
+conditions, express and implied, including warranties or conditions of title 
+and non-infringement, and implied warranties or conditions of merchantability 
+and fitness for a particular purpose;
+ii) effectively excludes on behalf of all Contributors all liability for 
+damages, including direct, indirect, special, incidental and consequential 
+damages, such as lost profits;
+iii) states that any provisions which differ from this Agreement are offered by 
+that Contributor alone and not by any other party; and
+iv) states that source code for the Program is available from such Contributor, 
+and informs licensees how to obtain it in a reasonable manner on or through a 
+medium customarily used for software exchange.
+When the Program is made available in source code form:
+
+a) it must be made available under this Agreement; and
+b) a copy of this Agreement must be included with each copy of the Program.
+Contributors may not remove or alter any copyright notices contained within the 
+Program.
+
+Each Contributor must identify itself as the originator of its Contribution, if 
+any, in a manner that reasonably allows subsequent Recipients to identify the 
+originator of the Contribution.
+
+4. COMMERCIAL DISTRIBUTION
+
+Commercial distributors of software may accept certain responsibilities with 
+respect to end users, business partners and the like. While this license is 
+intended to facilitate the commercial use of the Program, the Contributor who 
+includes the Program in a commercial product offering should do so in a manner 
+which does not create potential liability for other Contributors. Therefore, if 
+a Contributor includes the Program in a commercial product offering, such 
+Contributor ("Commercial Contributor") hereby agrees to defend and indemnify 
+every other Contributor ("Indemnified Contributor") against any losses, damages 
+and costs (collectively "Losses") arising from claims, lawsuits and other legal 
+actions brought by a third party against the Indemnified Contributor to the 
+extent caused by the acts or omissions of such Commercial Contributor in 
+connection with its distribution of the Program in a commercial product 
+offering. The obligations in this section do not apply to any claims or Losses 
+relating to any actual or alleged intellectual property infringement. In order 
+to qualify, an Indemnified Contributor must: a) promptly notify the Commercial 
+Contributor in writing of such claim, and b) allow the Commercial Contributor 
+to control, and cooperate with the Commercial Contributor in, the defense and 
+any related settlement negotiations. The Indemnified Contributor may 
+participate in any such claim at its own expense.
+
+For example, a Contributor might include the Program in a commercial product 
+offering, Product X. That Contributor is then a Commercial Contributor. If that 
+Commercial Contributor then makes performance claims, or offers warranties 
+related to Product X, those performance claims and warranties are such 
+Commercial Contributor's responsibility alone. Under this section, the 
+Commercial Contributor would have to defend claims against the other 
+Contributors related to those performance claims and warranties, and if a court 
+requires any other Contributor to pay any damages as a result, the Commercial 
+Contributor must pay those damages.
+
+5. NO WARRANTY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON AN 
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR 
+IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, 
+NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each 
+Recipient is solely responsible for determining the appropriateness of using 
+and distributing the Program and assumes all risks associated with its exercise 
+of rights under this Agreement , including but not limited to the risks and 
+costs of program errors, compliance with applicable laws, damage to or loss of 
+data, programs or equipment, and unavailability or interruption of operations.
+
+6. DISCLAIMER OF LIABILITY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY 
+CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST 
+PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY 
+WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE EXERCISE OF ANY RIGHTS 
+GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under applicable 
+law, it shall not affect the validity or enforceability of the remainder of the 
+terms of this Agreement, and without further action by the parties hereto, such 
+provision shall be reformed to the minimum extent necessary to make such 
+provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity (including a 
+cross-claim or counterclaim in a lawsuit) alleging that the Program itself 
+(excluding combinations of the Program with other software or hardware) 
+infringes such Recipient's patent(s), then such Recipient's rights granted 
+under Section 2(b) shall terminate as of the date such litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it fails to 
+comply with any of the material terms or conditions of this Agreement and does 
+not cure such failure in a reasonable period of time after becoming aware of 
+such noncompliance. If all Recipient's rights under this Agreement terminate, 
+Recipient agrees to cease use and distribution of the Program as soon as 
+reasonably practicable. However, Recipient's obligations under this Agreement 
+and any licenses granted by Recipient relating to the Program shall continue 
+and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement, but in 
+order to avoid inconsistency the Agreement is copyrighted and may only be 
+modified in the following manner. The Agreement Steward reserves the right to 
+publish new versions (including revisions) of this Agreement from time to time. 
+No one other than the Agreement Steward has the right to modify this Agreement. 
+The Eclipse Foundation is the initial Agreement Steward. The Eclipse Foundation 
+may assign the responsibility to serve as the Agreement Steward to a suitable 
+separate entity. Each new version of the Agreement will be given a 
+distinguishing version number. The Program (including Contributions) may always 
+be distributed subject to the version of the Agreement under which it was 
+received. In addition, after a new version of the Agreement is published, 
+Contributor may elect to distribute the Program (including its Contributions) 
+under the new version. Except as expressly stated in Sections 2(a) and 2(b) 
+above, Recipient receives no rights or licenses to the intellectual property of 
+any Contributor under this Agreement, whether expressly, by implication, 
+estoppel or otherwise. All rights in the Program not expressly granted under 
+this Agreement are reserved.
+
+This Agreement is governed by the laws of the State of New York and the 
+intellectual property laws of the United States of America. No party to this 
+Agreement will bring a legal action under this Agreement more than one year 
+after the cause of action arose. Each party waives its rights to a jury trial 
+in any resulting litigation.

--- a/CnCLPGParser/src/CnCParser/CncHcGenerator.java
+++ b/CnCLPGParser/src/CnCParser/CncHcGenerator.java
@@ -917,6 +917,9 @@ public class CncHcGenerator extends AbstractVisitor
 			buffer_commonhc.append("\n");
 			buffer_commonhc.append("#include \"Common.h\"\n\n");
 
+			buffer_commonhc.append("/* squelch unused variable warnings */\n");
+			buffer_commonhc.append("#define MAYBE_UNUSED(x) ((void)x)\n\n");
+
 			File file_commonh = new File (dir + "Common.h");
 			PrintStream stream_commonh = new PrintStream(file_commonh);
 			StringBuilder buffer_commonh = new StringBuilder();
@@ -1172,14 +1175,6 @@ public class CncHcGenerator extends AbstractVisitor
 			}
 			else {
 				throw new RuntimeException("Shouldn't have ranges in step tags.");
-				/*out.append("\t" + indextype + sc.getstart_range() + " = CNC_GET_FROM_TAG("+tagNameOCR+", "+sili+");\n");
-				prototype1.append(indextype + sc.getstart_range() +", ");
-				prototype2.append(sc.getstart_range()+", ");
-				sili++;
-				out.append("\t" + indextype + sc.getend_range() + " = CNC_GET_FROM_TAG("+tagNameOCR+", "+sili+");\n");
-				prototype1.append(indextype + sc.getend_range() +", ");
-				prototype2.append(sc.getend_range()+", ");
-				size++;*/
 			}
 			counter ++;
 		}

--- a/CnCLPGParser/src/CnCParser/CncHcGenerator.java
+++ b/CnCLPGParser/src/CnCParser/CncHcGenerator.java
@@ -558,8 +558,6 @@ public class CncHcGenerator extends AbstractVisitor
 			stream_contexth.println("Context *initGraph();");
 			stream_contexth.println("void deleteGraph(Context *CnCGraph);");
 			stream_contexth.println();
-			stream_contexth.printf("void cncPrescribe_cncEnvOut(%s);%n", environment.prescriberArgs);
-			stream_contexth.println();
 			stream_contexth.println("#endif /*_CONTEXT*/");
 			stream_contexth.println();
 		}
@@ -724,6 +722,8 @@ public class CncHcGenerator extends AbstractVisitor
 				String argList = si.prescriberArgs.replace(" Context ", " struct Context ");
 				stream_dispatchh.printf("void cncPrescribe_%s(%s);%n", step_name, argList);
 			}
+			String argList = environment.prescriberArgs.replace(" Context ", " struct Context ");
+			stream_dispatchh.printf("void __cncPrescribe_cncEnvOut(%s);%n", argList);
 			stream_dispatchh.println();
 			
 			if(fullauto){

--- a/CnCLPGParser/src/CnCParser/CncHcGenerator.java
+++ b/CnCLPGParser/src/CnCParser/CncHcGenerator.java
@@ -684,11 +684,11 @@ public class CncHcGenerator extends AbstractVisitor
 			stream_contextc.printf("void cncPrescribe_cncEnvOut(%s) {%n", environment.prescriberArgs);
 			stream_contextc.println("\tCncTagComponent *tagPtr;");
 			stream_contextc.println("\tocrGuid_t tagGuid;");
-			stream_contextc.println("\tint i=0;");
+			stream_contextc.println("\tint _paramI=0;");
 			stream_contextc.printf("\tint tagSize = sizeof(CncTagComponent) * %s;%n", environment.identifiers.size());
 			stream_contextc.println("\tCNC_CREATE_ITEM(&tagGuid, (void**)&tagPtr, tagSize);");
 			for (Object o : environment.identifiers.getList()) {
-				stream_contextc.printf("\ttagPtr[i++] = %s;%n", o);
+				stream_contextc.printf("\ttagPtr[_paramI++] = %s;%n", o);
 			}
 			stream_contextc.println("\tocrEventSatisfy(context->cncEnvOutTag, tagGuid);");
 			stream_contextc.println("}");

--- a/examples/choleskyFactorization/Main.c
+++ b/examples/choleskyFactorization/Main.c
@@ -40,36 +40,33 @@ void cncEnvIn(int argc, char **argv, Context *context) {
                 }
             }
             // Put the initialized tile
-            char *tempTag = CREATE_TAG(i, j, 0);
-            Put(tile_handle, tempTag, context->Lkji);
+            cncPut_Lkji(tile_handle, i, j, 0, context);
         }
     }
     // Clean up source matrix (no longer needed)
     FREE(A1D);
     
     // Put matrix and tile dimension info
-    char *tag = CREATE_TAG(0);
     int *ntPtr, *tPtr;
     cncHandle_t nt_handle = cncCreateItem_tileSize(&ntPtr);
     *ntPtr = nt;
-    Put(nt_handle, tag, context->numTiles);
+    cncPut_numTiles(nt_handle, 0, context);
     cncHandle_t t_handle = cncCreateItem_numTiles(&tPtr);
     *tPtr = t;
-    Put(t_handle, tag, context->tileSize);
+    cncPut_tileSize(t_handle, 0, context);
 
     // Record the starting time of the computation
     struct timeval *startTime;
     cncHandle_t time_handle = cncCreateItem_startTime(&startTime, 1);
     gettimeofday(startTime, 0);
-    Put(time_handle, tag, context->startTime);
+    cncPut_startTime(time_handle, 0, context);
 
     // Start the computation
-    CNC_PRESCRIBE(kComputeStep, tag, context);
+    cncPrescribe_kComputeStep(0, context);
 
     // Set tag for the output step
     int totalTileCount = nt * (nt + 1) / 2;
-    char *envOutTag = CREATE_TAG(totalTileCount);
-    setEnvOutTag(envOutTag, context);
+    cncPrescribe_cncEnvOut(totalTileCount, context);
 }
 
 void cncEnvOut(int tileCount, startTimeItem startTime, numTilesItem numTiles, tileSizeItem tileSize,

--- a/examples/choleskyFactorization/Makefile
+++ b/examples/choleskyFactorization/Makefile
@@ -8,6 +8,9 @@ OBJS=$(patsubst %.c,%.o,$(SRCS))
 # include header globally for user-defined types
 CFLAGS+=-include user_types.h
 
+# shut down CnC runtime even if some steps never finish
+#CFLAGS+=-DCNC_UNCLEAN_FINISH
+
 compile: $(TARGET)
 
 # building source files

--- a/examples/choleskyFactorization/kComputeStep.c
+++ b/examples/choleskyFactorization/kComputeStep.c
@@ -2,9 +2,8 @@
 #include "Common.h"
 void kComputeStep(int k, numTilesItem numTiles, Context *context) {
     for(k = 0; k < numTiles.item; k++){
-        char *tagcontrolS1Tag1 = CREATE_TAG(k);
-        CNC_PRESCRIBE(kjComputeStep, tagcontrolS1Tag1, context);
-        CNC_PRESCRIBE(s1ComputeStep, tagcontrolS1Tag1, context);
+        cncPrescribe_kjComputeStep(k, context);
+        cncPrescribe_s1ComputeStep(k, context);
     }
 }
 

--- a/examples/choleskyFactorization/kjComputeStep.c
+++ b/examples/choleskyFactorization/kjComputeStep.c
@@ -3,9 +3,8 @@
 void kjComputeStep(int k, numTilesItem numTiles, Context *context) {
     int j;
     for(j = k+1; j < numTiles.item; j++){
-        char *tagcontrolS2Tag1 = CREATE_TAG(k, j);
-        CNC_PRESCRIBE(kjiComputeStep, tagcontrolS2Tag1, context);
-        CNC_PRESCRIBE(s2ComputeStep, tagcontrolS2Tag1, context);
+        cncPrescribe_kjiComputeStep(k, j, context);
+        cncPrescribe_s2ComputeStep(k, j, context);
     }
 }
 

--- a/examples/choleskyFactorization/kjiComputeStep.c
+++ b/examples/choleskyFactorization/kjiComputeStep.c
@@ -3,8 +3,7 @@
 void kjiComputeStep(int k, int j, Context *context) {
     int i;
     for(i = k+1; i < j+1; i++){
-        char *tagcontrolS3Tag0 = CREATE_TAG(k, j, i);
-        CNC_PRESCRIBE(s3ComputeStep, tagcontrolS3Tag0, context);
+        cncPrescribe_s3ComputeStep(k, j, i, context);
     }
 }
 

--- a/examples/choleskyFactorization/s1ComputeStep.c
+++ b/examples/choleskyFactorization/s1ComputeStep.c
@@ -25,9 +25,8 @@ void s1ComputeStep(int k, tileSizeItem tileSize, LkjiItem Lkji1D, Context *conte
                 Lkji[ iB ][ jBB ] = Lkji[ iB ][ jBB ] - ( lBlock[ iB ][ kB ] * lBlock[ jBB ][ kB ] );
     }
 
-    char *tagLkji = CREATE_TAG(k, k, k+1);
-    Put(lBlock_handle, tagLkji, context->Lkji);
+    cncPut_Lkji(lBlock_handle, k, k, k+1, context);
 
-    char *tagResult = CREATE_TAG((k)*(k+1)/2 + k);
-    Put(lBlock_handle, tagResult, context->results);
+    int tagResult = (k)*(k+1)/2 + k;
+    cncPut_results(lBlock_handle, tagResult, context);
 }

--- a/examples/choleskyFactorization/s2ComputeStep.c
+++ b/examples/choleskyFactorization/s2ComputeStep.c
@@ -20,10 +20,9 @@ void s2ComputeStep(int k, int j, tileSizeItem tileSize, LkjiItem LkjiA1D, LkjiIt
                 LkjiA[ iB ][ jB ] -= LkjiB[ jB ][ kB ] * loBlock[ iB ][ kB ];
     }
 
-    char *tagLkji = CREATE_TAG(j, k, k+1);
-    Put(loBlock_handle, tagLkji, context->Lkji);
+    cncPut_Lkji(loBlock_handle, j, k, k+1, context);
 
-    char *tagResult = CREATE_TAG((j)*(j+1)/2 + k);
-    Put(loBlock_handle, tagResult, context->results);
+    int tagResult = (j)*(j+1)/2 + k;
+    cncPut_results(loBlock_handle, tagResult, context);
 }
 

--- a/examples/choleskyFactorization/s3ComputeStep.c
+++ b/examples/choleskyFactorization/s3ComputeStep.c
@@ -21,6 +21,5 @@ void s3ComputeStep(int k, int j, int i, tileSizeItem tileSize,
         }
     }
 
-    char *tagLkji = CREATE_TAG(j, i, k+1);
-    Put(LkjiA1D.handle, tagLkji, context->Lkji);
+    cncPut_Lkji(LkjiA1D.handle, j, i, k+1, context);
 }

--- a/examples/rangeTest/Main.c
+++ b/examples/rangeTest/Main.c
@@ -12,25 +12,18 @@ void cncEnvIn(int argc, char **argv, Context *context) {
     for(i = 0; i < 100; i++){
         cncHandle_t CollA_handle = cncCreateItem_CollA(&CollA[i], 1);
         *CollA[i] = i;
-        char *tagCollA = CREATE_TAG(i);
-        Put(CollA_handle, tagCollA, context->CollA);
+        cncPut_CollA(CollA_handle, i, context);
     }
 
     for(i = 0; i < 100; i++){
         cncHandle_t CollB_handle = cncCreateItem_CollB(&CollB[i]);
         *CollB[i] = i;
-        char *tagCollB = CREATE_TAG(i);
-        Put(CollB_handle, tagCollB, context->CollB);
+        cncPut_CollB(CollB_handle, i, context);
     }
 
-    char *tagSATag2 = CREATE_TAG(x, y);
-    CNC_PRESCRIBE(StepA, tagSATag2, context);
-
-    char *tagSBTag3 = CREATE_TAG(x, y);
-    CNC_PRESCRIBE(StepB, tagSBTag3, context);
-
-    char *tagOut = CREATE_TAG(x, y);
-    setEnvOutTag(tagOut, context);
+    cncPrescribe_StepA(x, y, context);
+    cncPrescribe_StepB(x, y, context);
+    cncPrescribe_cncEnvOut(x, y, context);
 }
 
 void cncEnvOut(int x, int y, TotalAItem TotalA, TotalBItem TotalB, Context* context) {

--- a/examples/rangeTest/StepA.c
+++ b/examples/rangeTest/StepA.c
@@ -11,7 +11,5 @@ void StepA(int i, int j, CollAItem *CollA, Context *context) {
     int *TotalA;
     cncHandle_t TotalA_handle = cncCreateItem_TotalA(&TotalA, 1);
     *TotalA = total;
-
-    char *tagTotalA = CREATE_TAG(i, j);
-    Put(TotalA_handle, tagTotalA, context->TotalA);
+    cncPut_TotalA(TotalA_handle, i, j, context);
 }

--- a/examples/rangeTest/StepB.c
+++ b/examples/rangeTest/StepB.c
@@ -11,9 +11,7 @@ void StepB(int i, int j, CollBItem *CollB, Context *context) {
     int *TotalB;
     cncHandle_t TotalB_handle = cncCreateItem_TotalB(&TotalB);
     *TotalB = total;
-
-    char *tagTotalB = CREATE_TAG(i, j);
-    Put(TotalB_handle, tagTotalB, context->TotalB);
+    cncPut_TotalB(TotalB_handle, i, j, context);
 }
 
 

--- a/examples/simpleTest/Main.c
+++ b/examples/simpleTest/Main.c
@@ -7,29 +7,24 @@ void cncEnvIn(int argc, char **argv, Context *context) {
     int *size;
     cncHandle_t size_handle = cncCreateItem_size(&size);
     *size=10;
-    char *tag = CREATE_TAG(0);
-    Put(size_handle, tag, context->size);
+    cncPut_size(size_handle, 0, context);
 
     //Create and put A
     int *k, i;    
     for (i=0; i<*size; i++){
         ocrGuid_t db_handle = cncCreateItem_Ai(&k, 1);
         *k = i;
-        char *tagl = CREATE_TAG(i);
-        Put(db_handle, tagl, context->Ai);
+        cncPut_Ai(db_handle, i, context);
     }
 
     PRINTF("Starting parallel computation\n");
 
-    CNC_PRESCRIBE(Step0, tag, context);
-
-    char *tag2 = CREATE_TAG(2);
-    setEnvOutTag(tag2, context);
+    cncPrescribe_Step0(0, context);
+    cncPrescribe_cncEnvOut(2, context);
 }
 
 void cncEnvOut(int i, CiItem Ci0, Context *context) {
     PRINTF("Finished parallel computation\n\n");
 
-    char *tag2 = CREATE_TAG(2);
-    PRINTF("Result=%d (from tag=%s)\n", *Ci0.item, tag2);
+    PRINTF("Result=%d (from tag=%d)\n", *Ci0.item, 2);
 }

--- a/examples/simpleTest/Step0.c
+++ b/examples/simpleTest/Step0.c
@@ -6,9 +6,7 @@ void Step0(int k, sizeItem size0, Context *context) {
 
 	int i;
 	for (i = 0; i < size0.item; i++) {
-		char *tagS1Tag1 = CREATE_TAG(i);
-		CNC_PRESCRIBE(Step1, tagS1Tag1, context);
+		cncPrescribe_Step1(i, context);
 	}
 }
-
 

--- a/examples/simpleTest/Step1.c
+++ b/examples/simpleTest/Step1.c
@@ -7,12 +7,8 @@ void Step1(int k, AiItem Ai, Context *context){
 	int *Bi;
 	cncHandle_t Bi_handle = cncCreateItem_Bi(&Bi, 1);
 	*Bi = *Ai.item + 1;
+	cncPut_Bi(Bi_handle, k, context);
 
-	char *tagBi = CREATE_TAG(k);
-	Put(Bi_handle, tagBi, context->Bi);
-
-	char *tagS2Tag2 = CREATE_TAG(k);
-	CNC_PRESCRIBE(Step2, tagS2Tag2, context);
-
+	cncPrescribe_Step2(k, context);
 }
 

--- a/examples/simpleTest/Step2.c
+++ b/examples/simpleTest/Step2.c
@@ -7,11 +7,9 @@ void Step2(int k, BiItem Bi, Context *context) {
 	int *Ci;
 	cncHandle_t Ci_handle = cncCreateItem_Ci(&Ci, 1);
 	*Ci = *Bi.item * 2;
+	cncPut_Ci(Ci_handle, k, context);
 
-	char *tagCi = CREATE_TAG(k);
-	Put(Ci_handle, tagCi, context->Ci);
-
-	PRINTF("Step2 done putting item %d with tag %s\n", *Ci, tagCi);
+	PRINTF("Step2 done putting item %d with tag %d\n", *Ci, k);
 }
 
 

--- a/examples/smithWaterman/Main.c
+++ b/examples/smithWaterman/Main.c
@@ -87,26 +87,26 @@ void cncEnvIn(int argc, char **argv, Context *context) {
     data->ntw = ntw;
     data->nth = nth;
     memcpy(data->score_matrix, ALIGNMENT_SCORES, sizeof(ALIGNMENT_SCORES));
-    Put(dataHandle, CREATE_TAG(0), context->data);
+    cncPut_data(dataHandle, 0, context);
 
     // Record starting time
     struct timeval *startTime;
     cncHandle_t startTime_handle = cncCreateItem_startTime(&startTime, 1);
     gettimeofday(startTime, 0);
-    Put(startTime_handle, CREATE_TAG(0), context->startTime);
+    cncPut_startTime(startTime_handle, 0, context);
 
     // Seed edges
-    CNC_PRESCRIBE(initAboveStep, CREATE_TAG(tw, ntw), context);
-    CNC_PRESCRIBE(initLeftStep,  CREATE_TAG(th, nth), context);
+    cncPrescribe_initAboveStep(tw, ntw, context);
+    cncPrescribe_initLeftStep(th, nth, context);
 
     int i, j;
     for(i = 0; i < nth; i++){
         for(j = 0; j < ntw; j++){
-            CNC_PRESCRIBE(swStep, CREATE_TAG(i, j), context);
+            cncPrescribe_swStep(i, j, context);
         }
     }
 
-    setEnvOutTag(CREATE_TAG(ntw, nth, tw), context);
+    cncPrescribe_cncEnvOut(ntw, nth, tw, context);
 }
 
 void cncEnvOut(int ntw, int nth, int tw, startTimeItem startTime, aboveItem above, Context *context) {

--- a/examples/smithWaterman/Makefile
+++ b/examples/smithWaterman/Makefile
@@ -8,6 +8,9 @@ OBJS=$(patsubst %.c,%.o,$(SRCS))
 # include header globally for user-defined types
 CFLAGS+=-include smithwaterman.h
 
+# shut down CnC runtime even if some steps never finish
+#CFLAGS+=-DCNC_UNCLEAN_FINISH
+
 compile: $(TARGET)
 
 # building source files

--- a/examples/smithWaterman/initAboveStep.c
+++ b/examples/smithWaterman/initAboveStep.c
@@ -10,7 +10,7 @@ void initAboveStep(int tw, int ntw, Context *context){
             // TODO - Why isn't this just 0?
             above[jj] = GAP_PENALTY*(j*tw+jj);
         }
-        Put(above_handle, CREATE_TAG(0, j), context->above);
+        cncPut_above(above_handle, 0, j, context);
     }
 }
 

--- a/examples/smithWaterman/initLeftStep.c
+++ b/examples/smithWaterman/initLeftStep.c
@@ -10,7 +10,7 @@ void initLeftStep(int th, int nth, Context *context) {
             // TODO - Why isn't this just 0?
             left[ii] = GAP_PENALTY*(i*th+ii);
         }
-        Put(left_handle, CREATE_TAG(i, 0), context->left);
+        cncPut_left(left_handle, i, 0, context);
     }
 }
 

--- a/examples/smithWaterman/swStep.c
+++ b/examples/smithWaterman/swStep.c
@@ -44,7 +44,7 @@ void swStep(int i, int j, dataItem data, aboveItem above, leftItem left, Context
     for (index = 0; index <= data.item->tw; index++) {
         below[index] = curr_tile[data.item->th][index];
     }
-    Put(below_handle, CREATE_TAG(i+1, j), context->above);
+    cncPut_above(below_handle, i+1, j, context);
     ASSERT(left.item[data.item->th] == below[0]);
 
     int *right;
@@ -52,7 +52,7 @@ void swStep(int i, int j, dataItem data, aboveItem above, leftItem left, Context
     for (index = 0; index <= data.item->th; index++) {
         right[index] = curr_tile[index][data.item->tw];
     }
-    Put(right_handle, CREATE_TAG(i, j+1), context->left);
+    cncPut_left(right_handle, i, j+1, context);
     ASSERT(above.item[data.item->tw] == right[0]);
 
     /* Cleanup */

--- a/src/DataDriven.c
+++ b/src/DataDriven.c
@@ -43,7 +43,7 @@ static unsigned long hash_function(unsigned char *str, int length) {
  */
 static ItemCollectionEntry * allocateEntryIfAbsent(
         ItemCollectionEntry * volatile * hashmap, unsigned char * tag,
-        int length, char creator, char isSingleAssignment) {
+        int length, char creator, bool isSingleAssignment) {
     int index = (hash_function(tag, length)) % TABLE_SIZE;
     ItemCollectionEntry * volatile current = hashmap[index];
 
@@ -107,7 +107,7 @@ static ItemCollectionEntry * allocateEntryIfAbsent(
 }
 
 /* Putting an item into the hashmap */
-static int _Put(ocrGuid_t item, char * tag, int tagLength, ItemCollectionEntry ** hashmap, char isSingleAssignment) {
+int __cncPut(ocrGuid_t item, char *tag, int tagLength, ItemCollectionEntry ** hashmap, bool isSingleAssignment) {
     
     CNC_ASSERT(tag != NULL, "Put - ERROR================%p\n");
 
@@ -124,14 +124,6 @@ static int _Put(ocrGuid_t item, char * tag, int tagLength, ItemCollectionEntry *
     ocrEventSatisfy(entry->event, item);
 
     return PUT_SUCCESS;
-}
-
-int cncPut(ocrGuid_t item, char * tag, int tagLength, ItemCollectionEntry ** hashmap){
-    return _Put(item, tag, tagLength, hashmap, SINGLE_ASSIGNMENT_ENFORCED);
-}
-
-int cncPutIfAbsent(ocrGuid_t item, char * tag, int tagLength, ItemCollectionEntry ** hashmap){
-    return _Put(item, tag, tagLength, hashmap, SKIP_SINGLE_ASSIGNMENT);
 }
 
 /* Register a step as a consumer of the item in the hasmap */

--- a/src/DataDriven.h
+++ b/src/DataDriven.h
@@ -16,18 +16,8 @@
 #include <ocr.h>
 
 #define TABLE_SIZE 512 /* TODO: Table size should be set by the user when initializing the item collection */
-#define _ROLLBACK_AND_REPLAY 0
-#define _DATA_DRIVEN 1
 
-#ifdef _DATA_DRIVEN
-#define _CNC_POLICY _DATA_DRIVEN
-#else
-#define _CNC_POLICY _ROLLBACK_AND_REPLAY
-#endif
-
-#define LIST_REMOVED 1
 #include "cnc.h"
-#include <stdarg.h>
 
 typedef ocrGuid_t cncHandle_t;
 
@@ -35,39 +25,31 @@ typedef struct ItemCollectionEntry ItemCollectionEntry;
 
 /* The structure to hold an item in the item collection */
 struct ItemCollectionEntry {
-  char * tag; /* Tags are NULL-terminated char arrays for now */
   ocrGuid_t event; /* The event representing the data item. Data will be put through the event when it is satisfied */
   ItemCollectionEntry * volatile nxt; /* The next bucket in the hashtable */
   char creator; /* Who created this entry (could be from a Put or a Get)*/
+  char tag[]; /* Tags are byte arrays, with a known length for each item collection */
 };
 
 #define DEPS_BUCKET 3 /* must be >=3 */
 
-int Put(cncHandle_t item, char * tag, ItemCollectionEntry ** hashmap);
+int cncPut(ocrGuid_t item, char * tag, int tagLength, ItemCollectionEntry ** hashmap);
 
-int PutIfAbsent(cncHandle_t item, char * tag, ItemCollectionEntry ** hashmap);
-void  __registerConsumer(char * tag, ItemCollectionEntry * volatile * hashmap, ocrGuid_t stepToRegister, u32 slot);
-
-char* createTag(int no_args, ...);
+int cncPutIfAbsent(ocrGuid_t item, char * tag, int tagLength, ItemCollectionEntry ** hashmap);
+void  __cncRegisterConsumer(char * tag, int tagLength, ItemCollectionEntry * volatile * hashmap, ocrGuid_t stepToRegister, u32 slot);
 
 /* warning for variadic macro support */
 #if __GNUC__ < 3 && !defined(__clang__) && __STDC_VERSION__ < 199901L && !defined(NO_VARIADIC_MACROS)
-#warning Your compiler might not support variadic macros, in which case the CREATE_TAG macro is not supported. You can instead use the createTag function with an explicit arg count. You can disable this warning by setting NO_VARIADIC_MACROS to 0, or disable the macro definitions by setting it to 1.
+#warning Your compiler might not support variadic macros, in which case the CNC_REQUIRE macro is not supported. You can disable this warning by setting NO_VARIADIC_MACROS to 0, or disable the macro definitions by setting it to 1.
 #endif
 
 #if !NO_VARIADIC_MACROS
-#define TAG_LENGTH(...) (sizeof((u64[]){__VA_ARGS__})/sizeof(u64))
-#define CREATE_TAG(...) createTag(TAG_LENGTH(__VA_ARGS__), __VA_ARGS__)
 #define CNC_REQUIRE(cond, ...) do { if (!(cond)) { PRINTF(__VA_ARGS__); ocrShutdown(); exit(1); } } while (0)
 #endif
 
-int getTag(char* tag, int pos);
-
-cncHandle_t cncGet(char* tag, ItemCollectionEntry ** hashmap);
-
-#define CNC_DESTROY_ITEM(handle) ocrDbDestroy(handle); // release full batch's memory
+#define CNC_GET_FROM_TAG(tag, pos) (((int*)(tag))[(pos)]);
+#define CNC_DESTROY_ITEM(handle) ocrDbDestroy(handle); // free datablock backing an item
 #define CNC_CREATE_ITEM(handle, ptr, size) DBCREATE(handle, ptr, size, DB_PROP_NONE, NULL_GUID, NO_ALLOC)
-#define CNC_PRESCRIBE(stepName, tag, context) (context->stepName.depf(tag, context))
 #define CNC_NULL_HANDLE NULL_GUID
 
 #endif /* _DATA_DRIVEN_H */

--- a/src/DataDriven.h
+++ b/src/DataDriven.h
@@ -22,6 +22,7 @@
 typedef ocrGuid_t cncHandle_t;
 
 typedef struct ItemCollectionEntry ItemCollectionEntry;
+typedef s32 CncTagComponent;
 
 /* The structure to hold an item in the item collection */
 struct ItemCollectionEntry {
@@ -33,10 +34,8 @@ struct ItemCollectionEntry {
 
 #define DEPS_BUCKET 3 /* must be >=3 */
 
-int cncPut(ocrGuid_t item, char * tag, int tagLength, ItemCollectionEntry ** hashmap);
-
-int cncPutIfAbsent(ocrGuid_t item, char * tag, int tagLength, ItemCollectionEntry ** hashmap);
-void  __cncRegisterConsumer(char * tag, int tagLength, ItemCollectionEntry * volatile * hashmap, ocrGuid_t stepToRegister, u32 slot);
+int __cncPut(cncHandle_t item, char *tag, int tagLength, ItemCollectionEntry ** hashmap, bool isSingleAssignment);
+void  __cncRegisterConsumer(char *tag, int tagLength, ItemCollectionEntry * volatile * hashmap, ocrGuid_t stepToRegister, u32 slot);
 
 /* warning for variadic macro support */
 #if __GNUC__ < 3 && !defined(__clang__) && __STDC_VERSION__ < 199901L && !defined(NO_VARIADIC_MACROS)
@@ -47,7 +46,7 @@ void  __cncRegisterConsumer(char * tag, int tagLength, ItemCollectionEntry * vol
 #define CNC_REQUIRE(cond, ...) do { if (!(cond)) { PRINTF(__VA_ARGS__); ocrShutdown(); exit(1); } } while (0)
 #endif
 
-#define CNC_GET_FROM_TAG(tag, pos) (((int*)(tag))[(pos)]);
+#define CNC_GET_FROM_TAG(tag, pos) (((CncTagComponent*)(tag))[(pos)]);
 #define CNC_DESTROY_ITEM(handle) ocrDbDestroy(handle); // free datablock backing an item
 #define CNC_CREATE_ITEM(handle, ptr, size) DBCREATE(handle, ptr, size, DB_PROP_NONE, NULL_GUID, NO_ALLOC)
 #define CNC_NULL_HANDLE NULL_GUID

--- a/src/DataDriven.h
+++ b/src/DataDriven.h
@@ -34,22 +34,20 @@ struct ItemCollectionEntry {
 
 #define DEPS_BUCKET 3 /* must be >=3 */
 
+#define CNC_SUCCESS 0
+#define CNC_ABORT 1
+
+#define CNC_GET_ENTRY 1
+#define CNC_PUT_ENTRY 2
+
+#define PUT_FAIL 1
+#define PUT_SUCCESS 0
+
+#define SINGLE_ASSIGNMENT_ENFORCED 1
+#define SKIP_SINGLE_ASSIGNMENT 0
+
 int __cncPut(cncHandle_t item, char *tag, int tagLength, ItemCollectionEntry ** hashmap, bool isSingleAssignment);
 void  __cncRegisterConsumer(char *tag, int tagLength, ItemCollectionEntry * volatile * hashmap, ocrGuid_t stepToRegister, u32 slot);
-
-/* warning for variadic macro support */
-#if __GNUC__ < 3 && !defined(__clang__) && __STDC_VERSION__ < 199901L && !defined(NO_VARIADIC_MACROS)
-#warning Your compiler might not support variadic macros, in which case the CNC_REQUIRE macro is not supported. You can disable this warning by setting NO_VARIADIC_MACROS to 0, or disable the macro definitions by setting it to 1.
-#endif
-
-#if !NO_VARIADIC_MACROS
-#define CNC_REQUIRE(cond, ...) do { if (!(cond)) { PRINTF(__VA_ARGS__); ocrShutdown(); exit(1); } } while (0)
-#endif
-
-#define CNC_GET_FROM_TAG(tag, pos) (((CncTagComponent*)(tag))[(pos)]);
-#define CNC_DESTROY_ITEM(handle) ocrDbDestroy(handle); // free datablock backing an item
-#define CNC_CREATE_ITEM(handle, ptr, size) DBCREATE(handle, ptr, size, DB_PROP_NONE, NULL_GUID, NO_ALLOC)
-#define CNC_NULL_HANDLE NULL_GUID
 
 #endif /* _DATA_DRIVEN_H */
 

--- a/src/cnc.h
+++ b/src/cnc.h
@@ -38,7 +38,7 @@
       if(code == CNC_ABORT) return 0;\
    } while(0);
 
-#define CNC_ASSERT(check, msg) { ASSERT((check) && msg); }
+#define CNC_ASSERT(check, msg) do { ASSERT((check) && msg); } while (0)
 
 /* squelch unused variable warnings */
 #define MAYBE_UNUSED(x) ((void)x)

--- a/src/cnc.h
+++ b/src/cnc.h
@@ -15,35 +15,22 @@
 #include "cnc_mm.h"
 #include <ocr.h>
 
-#define CNC_SUCCESS 0
-#define CNC_ABORT 1
-
-#define CNC_GET_ENTRY 1
-#define CNC_PUT_ENTRY 2
-
-#define PUT_FAIL 1
-#define PUT_SUCCESS 0
-
-#define SINGLE_ASSIGNMENT_ENFORCED 1
-#define SKIP_SINGLE_ASSIGNMENT 0
-
- /* A macro for CnC Get function. We need to use a macro in order to simulate exceptional behaviour,  
-  * if a step does a Get that returns the special value CNC_ABORT, we need to abort the step instead of continuing 
-  * the execution 
-  */
-#define CNC_GET(result,tag,collection,whoscalling)\
-   do { \
-      int code = __Get(result,tag,collection,whoscalling); \
-      cnc_free(tag);\
-      if(code == CNC_ABORT) return 0;\
-   } while(0);
-
 #define CNC_ASSERT(check, msg) do { ASSERT((check) && msg); } while (0)
 
-/* squelch unused variable warnings */
-#define MAYBE_UNUSED(x) ((void)x)
-
 struct Context;
+
+/* warning for variadic macro support */
+#if __GNUC__ < 3 && !defined(__clang__) && __STDC_VERSION__ < 199901L && !defined(NO_VARIADIC_MACROS)
+#warning Your compiler might not support variadic macros, in which case the CNC_REQUIRE macro is not supported. You can disable this warning by setting NO_VARIADIC_MACROS to 0, or disable the macro definitions by setting it to 1.
+#endif
+
+#if !NO_VARIADIC_MACROS
+#define CNC_REQUIRE(cond, ...) do { if (!(cond)) { PRINTF(__VA_ARGS__); ocrShutdown(); exit(1); } } while (0)
+#endif
+
+#define CNC_DESTROY_ITEM(handle) ocrDbDestroy(handle); // free datablock backing an item
+#define CNC_CREATE_ITEM(handle, ptr, size) DBCREATE(handle, ptr, size, DB_PROP_NONE, NULL_GUID, NO_ALLOC)
+#define CNC_NULL_HANDLE NULL_GUID
 
 #endif /* _CNC_H */
 


### PR DESCRIPTION
Each item collection XYZ with keys of generated functions cncCreateItem_XYZ and cncPut_XYZ, customized based on the item type and the shape of the item key. Each step collection ABC has a generated function cncPrescribe_ABC, customized based on the shape of the step tag. These changes allow the compiler to check for the correct type and shape of tags and keys, and also allows us to store tags/keys internally as integer values rather than cstrings.
